### PR TITLE
Fix overflowed content and external resource on some anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@ main {
   font-family: monospace;
   font-size: large;
   list-style-type: none;
+  overflow-x: scroll;
 }
 .diff li {
   margin: 0.1em 0;
@@ -91,8 +92,8 @@ table {
   <div class="intro">
     <h1>Type Language Differ</h1>
     <p>Welcome to the online
-      <a href="https://core.telegram.org/mtproto/TL">Type Language</a>
-      <a href="https://en.wikipedia.org/wiki/File_comparison">differ</a>!</p>
+      <a href="https://core.telegram.org/mtproto/TL" target="_blank">Type Language</a>
+      <a href="https://en.wikipedia.org/wiki/File_comparison" target="_blank">differ</a>!</p>
 
     <p>This page is meant to be used to assist Telegram developers to easily
       see the biggest changes between different TL layers. These layers are
@@ -110,7 +111,7 @@ table {
       see the changes.</p>
 
     <p>You can subscribe to the <a href="atom.xml">RSS feed</a> for updates
-      on new layers, or <a href="https://github.com/lonami/tl-differ">contribute
+      on new layers, or <a href="https://github.com/lonami/tl-differ" target="_blank">contribute
       to the repository</a> with the code used to build this site.</p>
 
     <p>Calculate diff

--- a/index.html
+++ b/index.html
@@ -92,8 +92,8 @@ table {
   <div class="intro">
     <h1>Type Language Differ</h1>
     <p>Welcome to the online
-      <a href="https://core.telegram.org/mtproto/TL" target="_blank">Type Language</a>
-      <a href="https://en.wikipedia.org/wiki/File_comparison" target="_blank">differ</a>!</p>
+      <a href="https://core.telegram.org/mtproto/TL">Type Language</a>
+      <a href="https://en.wikipedia.org/wiki/File_comparison">differ</a>!</p>
 
     <p>This page is meant to be used to assist Telegram developers to easily
       see the biggest changes between different TL layers. These layers are
@@ -111,7 +111,7 @@ table {
       see the changes.</p>
 
     <p>You can subscribe to the <a href="atom.xml">RSS feed</a> for updates
-      on new layers, or <a href="https://github.com/lonami/tl-differ" target="_blank">contribute
+      on new layers, or <a href="https://github.com/lonami/tl-differ">contribute
       to the repository</a> with the code used to build this site.</p>
 
     <p>Calculate diff

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ main {
   font-family: monospace;
   font-size: large;
   list-style-type: none;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .diff li {
   margin: 0.1em 0;


### PR DESCRIPTION
- fixed overflowed content in ul tags for smaller screens that looks like this before applying patch
![welp](https://github.com/Lonami/tl-differ/assets/65716674/05cc5ff5-1652-47c4-8b40-3bfb33bb2628)

- added target attribute to anchors for external resources like this repo, wiki page, etc